### PR TITLE
feat(core): 支持通过配置启用或禁用驼峰命名法

### DIFF
--- a/src/main/java/com/crzsc/plugin/utils/Constants.kt
+++ b/src/main/java/com/crzsc/plugin/utils/Constants.kt
@@ -22,6 +22,9 @@ object Constants {
     /** 是否在 legacy 样式中使用父目录作为变量名前缀 (默认 true) */
     const val KEY_NAMED_WITH_PARENT = "named_with_parent"
 
+    /** 是否使用驼峰命名法 (默认 true) */
+    const val KEY_NAMED_USE_CAMEL_CASE = "named_use_camel_case"
+
     /** 输出的文件名 */
     const val KEY_OUTPUT_FILENAME = "output_filename"
 

--- a/src/main/java/com/crzsc/plugin/utils/DartClassGenerator.kt
+++ b/src/main/java/com/crzsc/plugin/utils/DartClassGenerator.kt
@@ -962,10 +962,15 @@ $packageDecl
             withoutDiacritics
                 .replace(Regex("[\\s()\\[\\]{}'\"`!@#$%^&*+=|\\\\:;,<>?/]"), "_")
                 .replace(Regex("_+"), "_") // 将连续的下划线替换为单个
+                .replace("-", "_")// 将连字符替换为下划线
                 .trim('_') // 移除首尾的下划线
 
         // 转换为驼峰命名
-        var newName = filtered.toLowCamelCase(Regex("[-_.]"))
+        var newName = if (FileHelperNew.isNamedUseCamelCase(config)) {
+            filtered.toLowCamelCase(Regex("[-_.]"))
+        } else {
+            filtered
+        }
 
         // 处理以数字开头的情况 (Dart变量名不能以数字开头)
         if (newName.isNotEmpty() && newName[0].isDigit()) {

--- a/src/main/java/com/crzsc/plugin/utils/FileHelperNew.kt
+++ b/src/main/java/com/crzsc/plugin/utils/FileHelperNew.kt
@@ -157,6 +157,11 @@ object FileHelperNew {
         return readSetting(config, Constants.KEY_NAMED_WITH_PARENT) as Boolean? ?: true
     }
 
+    /** 是否使用驼峰命名法 (默认 true) */
+    fun isNamedUseCamelCase(config: ModulePubSpecConfig): Boolean {
+        return readSetting(config, Constants.KEY_NAMED_USE_CAMEL_CASE) as Boolean? ?: true
+    }
+
     /** 读取生成的类名配置 */
     fun getGeneratedClassName(config: ModulePubSpecConfig): String {
         return readSetting(config, Constants.KEY_CLASS_NAME) as String?


### PR DESCRIPTION
- 在常量中新增 KEY_NAMED_USE_CAMEL_CASE 以控制是否使用驼峰命名
- 在 FileHelperNew 中添加 isNamedUseCamelCase 方法读取该配置，默认启用
- 在 DartClassGenerator 生成变量名时根据配置决定是否转换为驼峰命名
- 优化变量名处理，新增对连字符替换为下划线的支持